### PR TITLE
build: change package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "translator-js",
+  "name": "@norman-huth/translator-js",
   "type": "module",
   "description": "JavaScript JSON Translator based on Laravel™ Translator",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
npm error 403: package name too similar to existing packages